### PR TITLE
Fixed default frequency last digit drop in settings_provider.cc

### DIFF
--- a/src/settings_provider.cc
+++ b/src/settings_provider.cc
@@ -32,6 +32,7 @@ string read(string section,string key)
 	if(result == ""){
 		cout<<"no frequency has been set. setting to default..."<<endl;
 		result=DEFAULTFREQ;
+		result.append(" ");
 	}
 	return result;
 }


### PR DESCRIPTION
(Not sure if I'm doing this right... no idea of github etiquette) but I have a patch for the issue where when the pirateradio uses the DEFAULTFREQ, 88.8, it doesn't cut off the last 8. Essentially I just padded the result string with a piece of whitespace when using DEFAULTFREQ. That way in getsettings(), the erase line will just delete the whitespace, retaining DEFAULTFREQ properly.