### PR TITLE
Update player.cc

### DIFF
--- a/src/player.cc
+++ b/src/player.cc
@@ -25,7 +25,7 @@ void legacy_rds_init()
 
 void init()
 {
-	system("/bin/su pi -c \"pulseaudio -D\"");
+	system("/usr/bin/sudo -u pi -s pulseaudio -D");
 	system("hciconfig hci0 piscan");
 }
 


### PR DESCRIPTION
On raspberry pi 3, pulseaudio would quit a couple of minutes after bootup.
The proposed changes appear to have fixed the problem on raspi3.