### PR TITLE
Moved mpradio executable to /bin/mpradio (system binaries)

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -80,7 +80,7 @@ else
 	make
 fi
 
-${CP} mpradio /home/pi/mpradio
+${CP} mpradio /bin/mpradio
 
 #Installing service units...
 cp -f ../install/need2recompile.service /etc/systemd/system/need2recompile.service

--- a/install/mpradio-bt@.service
+++ b/install/mpradio-bt@.service
@@ -5,6 +5,6 @@ Requires=bluetooth.service bluealsa.service
 Type=simple
 User=pi
 Group=lp
-ExecStart=/home/pi/mpradio %I
+ExecStart=/bin/mpradio %I
 [Install]
 WantedBy=multi-user.target

--- a/install/mpradio.service
+++ b/install/mpradio.service
@@ -5,7 +5,7 @@ After=network.target auditd.service
 [Service]
 Type=idle
 EnvironmentFile=/home/pi/.profile
-ExecStart=/bin/bash -l -c '/home/pi/mpradio'
+ExecStart=/bin/bash -l -c '/bin/mpradio'
 ExecReload=/bin/kill -HUP $MAINPID
 KillMode=control-group
 


### PR DESCRIPTION
This has the effect of avoiding a not-necessarily-obvious collision between the name of the executable and the name of the cloned repository in /home/pi ...

Just a small request. I'm sure it would have a positive effect on newcomers trying things out.