### PR TITLE
A couple more fixes for bluetooth-only users

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -57,8 +57,8 @@ ${CP} bt-setup.sh /bin/bt-setup.sh
 ${CP} mpradio-legacyRDS.sh /bin/mpradio-legacyRDS.sh
 ${CP} simple-agent /bin/simple-agent
 ${CP} 100-usb.rules /etc/udev/rules.d/100-usb.rules
-mkdir /pirateradio
-${CP} -f ../install/pirateradio.config /pirateradio/pirateradio.config
+mkdir -p /pirateradio
+${CP} ../install/pirateradio.config /pirateradio/pirateradio.config --backup --suffix=.bak
 
 mkdir -p /usr/lib/udev
 ${CP} bluetooth /usr/lib/udev/bluetooth

--- a/install/mpradio-legacyRDS.sh
+++ b/install/mpradio-legacyRDS.sh
@@ -6,7 +6,7 @@ JUMP=$(crudini --get /pirateradio/pirateradio.config RDS charsJump)
 sleep $INTERVAL
 
 getTitle(){
-	cat /home/pi/now_playing
+	[ -f /home/pi/now_playing ] && cat /home/pi/now_playing;
 }
 
 while true

--- a/src/player.cc
+++ b/src/player.cc
@@ -141,6 +141,8 @@ int play_bt(string device)
 	if(s.btBoost)
 		set_effects(sox_params);
 	
+	update_now_playing("Bluetooth");
+
 	string cmdline="arecord -D bluealsa -f cd -c 2 | sox -t raw -v "+s.btGain+" -G -b 16 -e signed -c 2 -r 44100 - -t wav - "+sox_params+" | "+output;
 
 	system(cmdline.c_str());


### PR DESCRIPTION
RE: commit `a13de5b`, the message should have been "Test for existence before `cat`ting `now_playing`". The `now_playing` file is only available when playing from storage; if there are no files at all, or only a bluetooth connection, this would cause error messages which would end up in `/var/log/daemon.log` and `/var/log/syslog`, amounting to >500MB of messages in a 24-hour period :(

RE: commit `de47dae`, just making a backup of the local `pirateradio.config` file on reinstallation, to give users a chance to get it out of the way. Should probably either ask the user which configuration file to use, or not overwrite at all, but this is likely the least intrusive fix.

Thank you. Apologies for the piecemeal pull requests, but I figure they're useful changes.