### PR TITLE
Added mp3-metadata reading, using id3lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Exclusively tested on Minimal Raspbian (ARM)
 - [x] Stream audio over FM or 3.5mm Jack (Bluetooth speaker via jack audio output)
 - [x] Send mp3 files to the Pi via Bluetooth
 - [x] Bluetooth OTA file management on the Pi with applications such as "Bluetooth Explorer Lite"
-- [ ] Read metadata from the mp3 files 
+- [x] Read metadata from the mp3 files 
 - [ ] Display Android notifications over RDS?
 - [ ] Bluetooth companion app (for android) 
 - [ ] Automatically partition the sdcard for a dedicated mp3 storage space (instead of using a USB drive)
@@ -52,8 +52,9 @@ resumePlayback=true   	;require persistentPlaylist to be enabled
 shuffle=true 
 
 [RDS]
-updateInterval=3      	;seconds between RDS refresh. lower values could result in RDS being ignored by your radio receiver
-charsJump=6           	;how many characters should shift between updates [1-8]
+updateInterval=3      				;seconds between RDS refresh. lower values could result in RDS being ignored by your radio receiver
+charsJump=6                             	;how many characters should shift between updates [1-8]
+rdsPattern=echo $ARTIST_NAME - $SONG_NAME 	;pattern which is passed to eval() to produce title
 
 ```
 # Usage

--- a/install/install.sh
+++ b/install/install.sh
@@ -21,7 +21,7 @@ else
 fi
 
 #Installing software dependencies...
-apt-get -y $INSTALL bluez pi-bluetooth python-gobject python-gobject-2 bluez-tools sox crudini libsox-fmt-mp3 python-dbus bluealsa obexpushd
+apt-get -y $INSTALL bluez pi-bluetooth python-gobject python-gobject-2 bluez-tools sox crudini libsox-fmt-mp3 python-dbus bluealsa obexpushd libid3-dev
 apt-get -y remove pulseaudio
 
 #Installing software needed to compile PiFmRDS..

--- a/install/mpradio-legacyRDS.sh
+++ b/install/mpradio-legacyRDS.sh
@@ -13,8 +13,8 @@ getTitle(){
 	[ -f /home/pi/now_playing ] && source /home/pi/now_playing
 
 	# Now, pass PATTERN to eval() to compose the pattern together
-	# E.g.: '%s: %s!!!' "$ARTIST_NAME" "$SONG_NAME" becomes "Stevie Wonder: Superstition!!!"
-	eval printf $PATTERN
+	# E.g.: "$ARTIST_NAME - $SONG_NAME" becomes "Stevie Wonder - Superstition"
+	eval $PATTERN
 }
 
 while true

--- a/install/mpradio-legacyRDS.sh
+++ b/install/mpradio-legacyRDS.sh
@@ -13,8 +13,8 @@ getTitle(){
 	[ -f /home/pi/now_playing ] && source /home/pi/now_playing
 
 	# Now, pass PATTERN to eval() to compose the pattern together
-	# E.g.: "$ARTIST_NAME - $SONG_NAME" becomes "Stevie Wonder - Superstition"
-	eval $PATTERN
+	# E.g.: '%s: %s!!!' "$ARTIST_NAME" "$SONG_NAME" becomes "Stevie Wonder: Superstition!!!"
+	eval printf $PATTERN
 }
 
 while true

--- a/install/mpradio-legacyRDS.sh
+++ b/install/mpradio-legacyRDS.sh
@@ -14,7 +14,7 @@ getTitle(){
 
 	# Now, pass PATTERN to eval() to compose the pattern together
 	# E.g.: "$ARTIST_NAME - $SONG_NAME" becomes "Stevie Wonder - Superstition"
-	eval $PATTERN
+	eval echo $PATTERN
 }
 
 while true

--- a/install/mpradio-legacyRDS.sh
+++ b/install/mpradio-legacyRDS.sh
@@ -21,8 +21,8 @@ while true
 do
 	title=$(getTitle)
 	echo $title
-        title_lenght=$(echo $title|wc -c)
-	finish=$((title_lenght+JUMP)) 
+        title_length=$(echo $title|wc -c)
+	finish=$((title_length+JUMP)) 
 
         for i in $(seq 9 $JUMP $finish);
         do

--- a/install/mpradio-legacyRDS.sh
+++ b/install/mpradio-legacyRDS.sh
@@ -2,11 +2,19 @@
 
 INTERVAL=$(crudini --get /pirateradio/pirateradio.config RDS updateInterval)
 JUMP=$(crudini --get /pirateradio/pirateradio.config RDS charsJump)
+PATTERN=$(crudini --get /pirateradio/pirateradio.config RDS rdsPattern)
 
 sleep $INTERVAL
 
 getTitle(){
-	[ -f /home/pi/now_playing ] && cat /home/pi/now_playing;
+
+	# Verify now_playing exists before sourcing it
+	# By sourcing it, we catch variables set by update_now_playing().
+	[ -f /home/pi/now_playing ] && source /home/pi/now_playing
+
+	# Now, pass PATTERN to eval() to compose the pattern together
+	# E.g.: "$ARTIST_NAME - $SONG_NAME" becomes "Stevie Wonder - Superstition"
+	eval $PATTERN
 }
 
 while true

--- a/install/pirateradio.config
+++ b/install/pirateradio.config
@@ -1,5 +1,5 @@
 [PIRATERADIO]
-frequency=95.1
+frequency=107.0
 btGain=1.7            	;gain setting for bluetooth streaming
 storageGain=1         	;gain setting for stored files streaming
 output=fm		;[fm/analog] for FM output or 3.5 mm jack output
@@ -11,6 +11,6 @@ resumePlayback=true   	;not yet implemented
 shuffle=true 
 
 [RDS]
-updateInterval=3      	                  ;seconds between RDS refresh. lower values could result in RDS being ignored by your radio receiver
-charsJump=6           	                  ;how many characters should shift between updates [1-8]
-rdsPattern=echo $ARTIST_NAME - $SONG_NAME ;Pattern which is passed to eval() to produce title
+updateInterval=3      				;seconds between RDS refresh. lower values could result in RDS being ignored by your radio receiver
+charsJump=6           				;how many characters should shift between updates [1-8]
+rdsPattern=echo $ARTIST_NAME - $SONG_NAME	;Pattern which is passed to eval() to produce title

--- a/install/pirateradio.config
+++ b/install/pirateradio.config
@@ -13,4 +13,4 @@ shuffle=true
 [RDS]
 updateInterval=3      				;seconds between RDS refresh. lower values could result in RDS being ignored by your radio receiver
 charsJump=6           				;how many characters should shift between updates [1-8]
-rdsPattern='%s - %s' "$ARTIST_NAME" "$SONG_NAME"	;Pattern which is passed to `eval printf` to produce title
+rdsPattern=echo $ARTIST_NAME - $SONG_NAME	;Pattern which is passed to eval() to produce title

--- a/install/pirateradio.config
+++ b/install/pirateradio.config
@@ -13,4 +13,4 @@ shuffle=true
 [RDS]
 updateInterval=3      				;seconds between RDS refresh. lower values could result in RDS being ignored by your radio receiver
 charsJump=6           				;how many characters should shift between updates [1-8]
-rdsPattern=echo $ARTIST_NAME - $SONG_NAME	;Pattern which is passed to eval() to produce title
+rdsPattern=$ARTIST_NAME - $SONG_NAME	;Pattern which is passed to eval() to produce title

--- a/install/pirateradio.config
+++ b/install/pirateradio.config
@@ -13,4 +13,4 @@ shuffle=true
 [RDS]
 updateInterval=3      				;seconds between RDS refresh. lower values could result in RDS being ignored by your radio receiver
 charsJump=6           				;how many characters should shift between updates [1-8]
-rdsPattern=echo $ARTIST_NAME - $SONG_NAME	;Pattern which is passed to eval() to produce title
+rdsPattern='%s - %s' "$ARTIST_NAME" "$SONG_NAME"	;Pattern which is passed to `eval printf` to produce title

--- a/install/pirateradio.config
+++ b/install/pirateradio.config
@@ -1,5 +1,5 @@
 [PIRATERADIO]
-frequency=107.0
+frequency=95.1
 btGain=1.7            	;gain setting for bluetooth streaming
 storageGain=1         	;gain setting for stored files streaming
 output=fm		;[fm/analog] for FM output or 3.5 mm jack output
@@ -11,5 +11,6 @@ resumePlayback=true   	;not yet implemented
 shuffle=true 
 
 [RDS]
-updateInterval=3      	;seconds between RDS refresh. lower values could result in RDS being ignored by your radio receiver
-charsJump=6           	;how many characters should shift between updates [1-8]
+updateInterval=3      	                  ;seconds between RDS refresh. lower values could result in RDS being ignored by your radio receiver
+charsJump=6           	                  ;how many characters should shift between updates [1-8]
+rdsPattern=echo $ARTIST_NAME - $SONG_NAME ;Pattern which is passed to eval() to produce title

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,7 +2,7 @@ OBJ = mpradio.o player.o settings_provider.o files.o libs/inih/ini.o libs/inih/c
 CXXFLAGS=-Wall 
 
 mpradio: $(OBJ)
-	g++ -pthread -o mpradio $(OBJ)
+	g++ -pthread -o mpradio $(OBJ) -lid3
 
 -include dependencies
 

--- a/src/datastruct.h
+++ b/src/datastruct.h
@@ -18,7 +18,11 @@ struct settings{
 };
 
 struct playbackStatus{
+	string songPath;
 	string songName;
+	string songArtist;
+	string songAlbum;
+	string songYear;
 	int songIndex=0;
 	int playbackPosition=0;
 	bool resumed=false;

--- a/src/files.cc
+++ b/src/files.cc
@@ -148,8 +148,8 @@ void load_playback_status()
 	}
 }
 
-
-
+/*! \brief Update the ~/now_playing file to communicate metadata of current song. 
+ */
 void update_now_playing()
 {
 	ofstream playing;

--- a/src/files.cc
+++ b/src/files.cc
@@ -148,11 +148,17 @@ void load_playback_status()
 	}
 }
 
-void update_now_playing(string songname)
+
+
+void update_now_playing()
 {
 	ofstream playing;
 	playing.open("/home/pi/now_playing");
-	playing<<songname;
+	playing<<"SONG_NAME='"<<ps.songName<<"'\n"
+		   <<"SONG_YEAR='"<<ps.songYear<<"'\n"
+		   <<"ALBUM_NAME='"<<ps.songAlbum<<"'\n"
+		   <<"ARTIST_NAME='"<<ps.songArtist<<"'"
+		   <<endl;
 	playing.close();
 }
 

--- a/src/files.h
+++ b/src/files.h
@@ -8,5 +8,5 @@ int get_file_bs(int filesize,float fileduration);
 float get_song_duration(string path);
 void load_playback_status();
 void update_playback_status();
-void update_now_playing(string songname);
+void update_now_playing();
 

--- a/src/player.cc
+++ b/src/player.cc
@@ -82,6 +82,10 @@ void set_effects(string &sox_params)
 	sox_params+="compand 0.3,1 6:-70,-60,-20 -5 -90 0.2";
 }
 
+/*! \brief Read the contents of the ID3tag on the file at songpath
+ *         into playbackStatus ps, so that we can keep track of them.
+ * @param[in]  songpath String representing the full filepath of current song.
+ */
 void read_tag_to_status(string songpath)
 {
 	ID3_Tag tag(songpath.c_str());

--- a/src/player.cc
+++ b/src/player.cc
@@ -3,9 +3,13 @@
 #include <list>
 #include <thread>
 #include <sys/stat.h>
+#include <id3/tag.h>
+#include <id3/misc_support.h>
 using namespace std;
 #include "datastruct.h"
 #include "files.h"
+
+#define SAFE_NULL(X) (NULL == X ? "" : X)
 
 constexpr auto RDS_CTL= "/home/pi/rds_ctl";
 
@@ -78,6 +82,23 @@ void set_effects(string &sox_params)
 	sox_params+="compand 0.3,1 6:-70,-60,-20 -5 -90 0.2";
 }
 
+void read_tag_to_status(string songpath)
+{
+	ID3_Tag tag(songpath.c_str());
+	
+	ps.songPath = songpath;
+	ps.songName = SAFE_NULL(ID3_GetTitle( &tag ));
+	ps.songArtist = SAFE_NULL(ID3_GetArtist( &tag ));
+	ps.songAlbum = SAFE_NULL(ID3_GetAlbum( &tag ));
+	ps.songYear = SAFE_NULL(ID3_GetYear( &tag ));
+
+	if(ps.songName.empty()) {
+		size_t found = songpath.find_last_of("/");	/**< extract song name out of the absolute file path */
+		string songname=songpath.substr(found+1);
+		ps.songName=songname;			
+	}
+}
+
 int play_storage()
 {
 	bool repeat = true;
@@ -109,18 +130,17 @@ int play_storage()
 			advance (it,ps.songIndex);
 			songpath=*it;
 
-			size_t found = songpath.find_last_of("/");	/**< extract song name out of the absolute file path */
-	  		string songname=songpath.substr(found+1);
-			ps.songName=songname;
 			cout<<endl<<"PLAY: "<<songpath<<endl;
-	
-			sox=trim_audio_track(songpath)+sox;		/**< substitute songname with stdin (-) from dd if playback must be resumed */
-			output=pifm1+" "+"\""+songname+"\""+" "+pifm2+" "+"\""+songname+"\""+" "+pifm3+" "+s.freq;
+
+			read_tag_to_status(songpath);
+			
+			sox=trim_audio_track(songpath)+sox;		/**< substitute ps.songName with stdin (-) from dd if playback must be resumed */
+			output=pifm1+" "+"\""+ps.songName+"\""+" "+pifm2+" "+"\""+ps.songName+"\""+" "+pifm3+" "+s.freq;
 			set_output(output);			/**< change output device if specified */
 	
 			string cmdline=sox+" "+songpath+" "+sox_params+" | "+output;
 	
-			update_now_playing(songname);
+			update_now_playing();
 
 			system(cmdline.c_str());
 
@@ -140,8 +160,9 @@ int play_bt(string device)
 	set_output(output);			/**< change output device if specified */
 	if(s.btBoost)
 		set_effects(sox_params);
-	
-	update_now_playing("Bluetooth");
+
+	ps.songName = "Bluetooth";
+	update_now_playing();
 
 	string cmdline="arecord -D bluealsa -f cd -c 2 | sox -t raw -v "+s.btGain+" -G -b 16 -e signed -c 2 -r 44100 - -t wav - "+sox_params+" | "+output;
 


### PR DESCRIPTION
This update accomplishes the following:

* Installer now automatically installs `libid3-dev,` for parsing many forms of mp3-metadata
* player.cc now attempts to read mp3 tag metadata from files, storing it in playbackStatus `ps`
  - By default, if there is no tag on the file containing a file, `ps.songName` defaults back to `songname`, so tagless files should behave identically to before.
* `update_now_playing()` now writes what metadata it finds to now_playing in a Bash-readable format
* This enables the RDS service on `mpradio-legacyRDS.sh` to print information about a song, using a formatting string defined in `pirateradio.config`